### PR TITLE
fix logrotate.conf.skeleton and rsyslog.conf.skeleton

### DIFF
--- a/config/logrotate.conf.skeleton
+++ b/config/logrotate.conf.skeleton
@@ -1,9 +1,15 @@
-${LOG_PATH}/main.log {
+${LOG_PATH}/*.log {
     missingok
     compress
     delaycompress
-    dateformat .%Y-%m-%d
+    dateext
+    dateformat .%Y-%m-%d-%H
 
     daily
+    maxsize 10M
     rotate 10
+
+    postrotate
+        invoke-rc.d rsyslog rotate > /dev/null
+    endscript
 }

--- a/config/rsyslog.conf.skeleton
+++ b/config/rsyslog.conf.skeleton
@@ -1,3 +1,8 @@
+$Umask 0000
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0644
+
 if $msg contains "${NAME}" then \
     ${LOG_PATH}/main.log
     & ~


### PR DESCRIPTION
logrotate.conf.skeleton

- add "dateext" to enable "dateformat"
- add "maxsize"
- add "postrotate" for rsyslog

rsyslog.conf.skeleton

- add file owner, group, mode